### PR TITLE
Fix dateutil requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ required = [
     'pytz',
     'dateparser',
     'iso8601',
-    'dateutil.parser'
+    'python-dateutil'
 ]
 
 setup(


### PR DESCRIPTION
Fix package name for `dateutil.parser` requirement in `setup.py`. 

Now it's installable ;)