### PR TITLE
my_modules -> py_modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     author='Kenneth Reitz',
     author_email='me@kennethreitz.com',
     url='https://github.com/kennethreitz/maya',
-    my_modules=['maya'],
+    py_modules=['maya'],
     install_requires=required,
     license='MIT',
     classifiers=(


### PR DESCRIPTION
I couldn't import maya after pip installing (also reported in issue #11).. Fixing this parameter name seems to sort it out.