### PR TITLE
Added tzlocal to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ required = [
     'dateparser',
     'iso8601',
     'python-dateutil',
-    'ruamel.yaml'
+    'ruamel.yaml',
+    'tzlocal'
 ]
 
 setup(


### PR DESCRIPTION
We also require `tzlocal`.  I had installed it in my virtualenv accidentally but when rerunning on a clean env, `maya` doesn't work without `tzlocal`.