### PR TITLE
'week' and 'weekday' as properties to 'MayaDT' object

### DIFF
--- a/maya.py
+++ b/maya.py
@@ -141,6 +141,15 @@ class MayaDT(object):
         return self.datetime().day
 
     @property
+    def week(self):
+        return self.datetime().isocalendar()[1]
+
+    @property
+    def weekday(self):
+        """Return the day of the week as an integer. Monday is 1 and Sunday is 7"""
+        return self.datetime().isoweekday()
+
+    @property
     def hour(self):
         return self.datetime().hour
 


### PR DESCRIPTION
I think it will be good to also add `week` and `weekday` to the properties of MayaDT. It will be much more convenient to user to access it like: `maya_date.week` and `maya_date.weekday` (similar to `maya_date.month` and `maya_date.year`.

`weekday` will be `isoweekday()` of `datetime` object with Monday as 1 and Sunday as 7

