### PR TITLE
Fix rst headings in AUTHORS file

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,12 +1,14 @@
+Contributions to the maya project
+=================================
 
-# Contributions to the maya project
-
-## Creator & Maintainer
+Creator & Maintainer
+--------------------
 
 - Kenneth Reitz <me@kennethreitz.org> `@kennethreitz <https://github.com/kennethreitz>`_
 
 
-## Contributors
+Contributors
+------------
 
 In chronological order:
 


### PR DESCRIPTION
The rst formatted AUTHORS file was using markdown headings - I've changed those to valid rst syntax.