### PR TITLE
Remove sub protocol

### DIFF
--- a/maya.py
+++ b/maya.py
@@ -51,10 +51,6 @@ class MayaDT(object):
         return format(self.datetime(), *args, **kwargs)
 
     @validate_type_mayadt
-    def __sub__(self, maya_dt):
-        return MayaDT(self._epoch - maya_dt._epoch)
-
-    @validate_type_mayadt
     def __eq__(self, maya_dt):
         return self._epoch == maya_dt._epoch
 


### PR DESCRIPTION
> For example- Arrow supports floors and ceilings and **spans of dates**, which Maya does not at all.

To implement the `__sub__` protocol is not what we want for maya, right?

In case we do we shouldn't implement date spans with the `MayaDT` object - it's really not suited for that:

```python
>>> import maya
>>>
>>>
>>> now = maya.now()
>>> tomorrow = maya.when('tomorrow')
>>> (now - tomorrow).rfc2822()
'Tue, 30 Dec 1969 23:59:53 GMT'
>>> 
>>> 
>>> dt = maya.parse('February 21, 1994')
>>> dt2 = maya.parse('May 28, 2000')
>>> (dt2 - dt).rfc2822()
'Wed, 07 Apr 1976 00:00:00 GMT'
>>> 
```