### PR TITLE
Type checks in comparison operators

### DIFF
--- a/maya.py
+++ b/maya.py
@@ -37,47 +37,45 @@ class MayaDT(object):
         """Return's the datetime's format"""
         return format(self.datetime(), *args, **kwargs)
 
+    def _validate_type_mayadt(operator):
+        """
+        Decorator to validate all the arguments to function
+        are of type `MayaDT`
+        """
+        def inner(function):
+            def wrapper(self, *args, **kwargs):
+                for arg in args + tuple(kwargs.values()):
+                    if not isinstance(arg, self.__class__):
+                        raise TypeError('unorderable types: {}() {} {}()'.format(
+                                type(self).__name__, operator, type(arg).__name__))
+                return function(self, *args, **kwargs)
+            return wrapper
+
+        return inner
+
+    @_validate_type_mayadt('==')
     def __eq__(self, maya_dt):
-        try:
-            return self._epoch == maya_dt._epoch
-        except AttributeError:
-            raise TypeError('unorderable types: {}() == {}()'.format(
-                type(self).__name__, type(maya_dt).__name__))
+        return self._epoch == maya_dt._epoch
 
+    @_validate_type_mayadt('!=')
     def __ne__(self, maya_dt):
-        try:
-            return self._epoch != maya_dt._epoch
-        except AttributeError:
-            raise TypeError('unorderable types: {}() != {}()'.format(
-                type(self).__name__, type(maya_dt).__name__))
+        return self._epoch != maya_dt._epoch
 
+    @_validate_type_mayadt('<')
     def __lt__(self, maya_dt):
-        try:
-            return self._epoch < maya_dt._epoch
-        except AttributeError:
-            raise TypeError('unorderable types: {}() < {}()'.format(
-                type(self).__name__, type(maya_dt).__name__))
+        return self._epoch < maya_dt._epoch
 
+    @_validate_type_mayadt('<=')
     def __le__(self, maya_dt):
-        try:
-            return self._epoch <= maya_dt._epoch
-        except AttributeError:
-            raise TypeError('unorderable types: {}() <= {}()'.format(
-                type(self).__name__, type(maya_dt).__name__))
+        return self._epoch <= maya_dt._epoch
 
+    @_validate_type_mayadt('>')
     def __gt__(self, maya_dt):
-        try:
-            return self._epoch > maya_dt._epoch
-        except AttributeError:
-            raise TypeError('unorderable types: {}() > {}()'.format(
-                type(self).__name__, type(maya_dt).__name__))
+        return self._epoch > maya_dt._epoch
 
+    @_validate_type_mayadt('>=')
     def __ge__(self, maya_dt):
-        try:
-            return self._epoch >= maya_dt._epoch
-        except AttributeError:
-            raise TypeError('unorderable types: {}() >= {}()'.format(
-                type(self).__name__, type(maya_dt).__name__))
+        return self._epoch >= maya_dt._epoch
 
 
     # Timezone Crap

--- a/maya.py
+++ b/maya.py
@@ -23,19 +23,6 @@ from tzlocal import get_localzone
 _EPOCH_START = (1970, 1, 1)
 
 
-def validate_type_mayadt(func):
-    """
-    Decorator to validate all the arguments to function
-    are of type `MayaDT`
-    """
-    def inner(*args, **kwargs):
-        for arg in args + tuple(kwargs.values()):
-            if not isinstance(arg, MayaDT):
-                raise ValueError("Operation allowed only on object of type '{}'".format(MayaDT.__name__))
-        return func(*args, **kwargs)
-    return inner
-
-
 class MayaDT(object):
     """The Maya Datetime object."""
 
@@ -50,29 +37,47 @@ class MayaDT(object):
         """Return's the datetime's format"""
         return format(self.datetime(), *args, **kwargs)
 
-    @validate_type_mayadt
     def __eq__(self, maya_dt):
-        return self._epoch == maya_dt._epoch
+        try:
+            return self._epoch == maya_dt._epoch
+        except AttributeError:
+            raise TypeError('unorderable types: {}() == {}()'.format(
+                type(self).__name__, type(maya_dt).__name__))
 
-    @validate_type_mayadt
     def __ne__(self, maya_dt):
-        return not self.__eq__(maya_dt)
+        try:
+            return self._epoch != maya_dt._epoch
+        except AttributeError:
+            raise TypeError('unorderable types: {}() != {}()'.format(
+                type(self).__name__, type(maya_dt).__name__))
 
-    @validate_type_mayadt
     def __lt__(self, maya_dt):
-        return self._epoch < maya_dt._epoch
+        try:
+            return self._epoch < maya_dt._epoch
+        except AttributeError:
+            raise TypeError('unorderable types: {}() < {}()'.format(
+                type(self).__name__, type(maya_dt).__name__))
 
-    @validate_type_mayadt
     def __le__(self, maya_dt):
-        return self.__lt__(maya_dt) or self.__eq__(maya_dt)
+        try:
+            return self._epoch <= maya_dt._epoch
+        except AttributeError:
+            raise TypeError('unorderable types: {}() <= {}()'.format(
+                type(self).__name__, type(maya_dt).__name__))
 
-    @validate_type_mayadt
     def __gt__(self, maya_dt):
-        return self._epoch > maya_dt._epoch
+        try:
+            return self._epoch > maya_dt._epoch
+        except AttributeError:
+            raise TypeError('unorderable types: {}() > {}()'.format(
+                type(self).__name__, type(maya_dt).__name__))
 
-    @validate_type_mayadt
     def __ge__(self, maya_dt):
-        return self.__gt__(maya_dt) or self.__eq__(maya_dt)
+        try:
+            return self._epoch >= maya_dt._epoch
+        except AttributeError:
+            raise TypeError('unorderable types: {}() >= {}()'.format(
+                type(self).__name__, type(maya_dt).__name__))
 
 
     # Timezone Crap

--- a/maya.py
+++ b/maya.py
@@ -23,6 +23,26 @@ from tzlocal import get_localzone
 _EPOCH_START = (1970, 1, 1)
 
 
+def validate_class_type_arguments(operator):
+    """
+    Decorator to validate all the arguments to function
+    are of the type of calling class
+    """
+
+    def inner(function):
+        def wrapper(self, *args, **kwargs):
+            for arg in args + tuple(kwargs.values()):
+                if not isinstance(arg, self.__class__):
+                    raise TypeError('unorderable types: {}() {} {}()'.format(
+                        type(self).__name__, operator, type(arg).__name__))
+            return function(self, *args, **kwargs)
+
+        return wrapper
+
+    return inner
+
+
+
 class MayaDT(object):
     """The Maya Datetime object."""
 
@@ -40,43 +60,28 @@ class MayaDT(object):
         """Return's the datetime's format"""
         return format(self.datetime(), *args, **kwargs)
 
-    def _validate_type_mayadt(operator):
-        """
-        Decorator to validate all the arguments to function
-        are of type `MayaDT`
-        """
-        def inner(function):
-            def wrapper(self, *args, **kwargs):
-                for arg in args + tuple(kwargs.values()):
-                    if not isinstance(arg, self.__class__):
-                        raise TypeError('unorderable types: {}() {} {}()'.format(
-                                type(self).__name__, operator, type(arg).__name__))
-                return function(self, *args, **kwargs)
-            return wrapper
 
-        return inner
-
-    @_validate_type_mayadt('==')
+    @validate_class_type_arguments('==')
     def __eq__(self, maya_dt):
         return self._epoch == maya_dt._epoch
 
-    @_validate_type_mayadt('!=')
+    @validate_class_type_arguments('!=')
     def __ne__(self, maya_dt):
         return self._epoch != maya_dt._epoch
 
-    @_validate_type_mayadt('<')
+    @validate_class_type_arguments('<')
     def __lt__(self, maya_dt):
         return self._epoch < maya_dt._epoch
 
-    @_validate_type_mayadt('<=')
+    @validate_class_type_arguments('<=')
     def __le__(self, maya_dt):
         return self._epoch <= maya_dt._epoch
 
-    @_validate_type_mayadt('>')
+    @validate_class_type_arguments('>')
     def __gt__(self, maya_dt):
         return self._epoch > maya_dt._epoch
 
-    @_validate_type_mayadt('>=')
+    @validate_class_type_arguments('>=')
     def __ge__(self, maya_dt):
         return self._epoch >= maya_dt._epoch
 

--- a/test_maya.py
+++ b/test_maya.py
@@ -138,3 +138,17 @@ def test_comparison_operations():
 
     assert (now >= now_copy) is True
     assert (now >= tomorrow) is False
+
+    # Check Exceptions
+    with pytest.raises(TypeError):
+        now == 1
+    with pytest.raises(TypeError):
+        now != 1
+    with pytest.raises(TypeError):
+        now < 1
+    with pytest.raises(TypeError):
+        now <= 1
+    with pytest.raises(TypeError):
+        now > 1
+    with pytest.raises(TypeError):
+        now >= 1


### PR DESCRIPTION
This PR is addressing the issue https://github.com/kennethreitz/maya/issues/33

Updated error message according to Python's in-built errors:
```

>>> 1 < 'hello'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unorderable types: int() < str()
```

Also, we should not be calling comparison function from within other comparison function having relationship. As per the [Python 3 document](https://docs.python.org/3/reference/datamodel.html#object.__lt__): 

> By default, `__ne__()` delegates to `__eq__()` and inverts the result unless it is `NotImplemented`. There are no other implied relationships among the comparison operators, for example, the truth of `(x<y or x==y)` does not imply `x<=y`.