### PR TITLE
use local timezone to get the slang date

### DIFF
--- a/maya.py
+++ b/maya.py
@@ -213,7 +213,8 @@ class MayaDT(object):
 
     def slang_date(self):
         """"Returns human slang representation of date."""
-        return humanize.naturaldate(self.datetime())
+        dt = self.datetime(naive=True, to_timezone=self.local_timezone)
+        return humanize.naturaldate(dt)
 
     def slang_time(self):
         """"Returns human slang representation of time."""


### PR DESCRIPTION
Fix for issue: https://github.com/kennethreitz/maya/issues/36

Use local timezone to get the slang_date. Similar behavior is followed in `slang_time` function: https://github.com/kennethreitz/maya/blob/master/maya.py#L220