### PR TITLE
Fix file encoding issues preventing successful pip installation on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,9 @@ except ImportError:
 
 here = os.path.abspath(dirname(__file__))
 
-def read(*parts):
-    return codecs.open(os.path.join(here, *parts), 'r').read()
+with codecs.open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
+    long_description = '\n' + f.read()
+
 
 if sys.argv[-1] == "publish":
     os.system("python setup.py sdist bdist_wheel upload")
@@ -37,7 +38,7 @@ setup(
     name='maya',
     version='0.1.4',
     description='Datetimes for Humans.',
-    long_description= '\n' + read('README.rst'),
+    long_description=long_description,
     author='Kenneth Reitz',
     author_email='me@kennethreitz.com',
     url='https://github.com/kennethreitz/maya',


### PR DESCRIPTION
This PR should fix issue #10. Sorry about the duplicate--read my comments on PR #40 to see what happened, I'm completely new to contributing to open source!

The README file is now read correctly by `codecs.open` with utf-8 encoding into the setup's `long_description`.

After this fix, I was able to successfully build and install a wheel in Windows `cmd` with `python setup.py bdist_wheel` and `pip install dist\maya-0.1.4-py3-none-any.whl` :)
