### PR TITLE
Fix erroneous test logic in test_dt_tz_translation, test_dt_tz_naive

### DIFF
--- a/test_maya.py
+++ b/test_maya.py
@@ -36,7 +36,7 @@ def test_machine_parse():
 def test_dt_tz_translation():
     d1 = maya.now().datetime()
     d2 = maya.now().datetime(to_timezone='US/Eastern')
-    assert d1.hour - d2.hour == 5
+    assert (d1.hour - d2.hour) % 24 == 5
 
 
 def test_dt_tz_naive():
@@ -45,7 +45,7 @@ def test_dt_tz_naive():
 
     d2 = maya.now().datetime(to_timezone='US/Eastern', naive=True)
     assert d2.tzinfo is None
-    assert d1.hour - d2.hour == 5
+    assert (d1.hour - d2.hour) % 24 == 5
 
 
 def test_random_date():


### PR DESCRIPTION
This PR fixes the failed `test_dt_tz_translation` and `test_dt_tz_naive` tests as seen in PR #41.

The old testing logic `assert d1.hour - d2.hour == 5` worked under the assumption that d1.hour is always greater than d2.hour, but this isn't the case from 7 PM to 11 PM (hours 19 - 23) EST, during which the GMT conversion is wrapped back to hours 12 AM to 4 AM (hours 0 - 4).

Hence, the current tests will only succeed 19 out of 24 hours in a day! Now they will pass at any time of day 🎉  🎉  🎉  