### PR TITLE
Support Python 3.3, 3.4, 3.5, 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: python
 python:
   - "2.7"
-  # - "3.5" # looks like ruamel.ordereddict doesn't build for python3
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install: pip install -r requirements.txt
 # command to run tests
 script: make

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e . 
+-e .
 dateparser==0.5.0
 humanize==0.5.1
 iso8601==0.1.11
@@ -8,7 +8,8 @@ pytest==3.0.5
 python-dateutil==2.6.0
 pytz==2016.10
 regex==2016.11.21
-ruamel.ordereddict==0.4.9
+#ruamel.ordereddict is only needed for python 2
+#ruamel.ordereddict==0.4.9
 ruamel.yaml==0.13.4
 six==1.10.0
 typing==3.5.2.2


### PR DESCRIPTION
Support/Test against Python 3.3, 3.4, 3.5, 3.6

ruamel.ordereddict is only needed for Python 2.7 (and only installed as a dependency from *ruamel.yaml* for Python 2.7).
There is actually no way to currently handle such a thing in the *requirements.txt*.
Thus, I've just removed it there and with that we are able to test against Python 3 versions with travis.