### PR TITLE
Improve iso8601 parsing

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -20,3 +20,4 @@ In chronological order:
 - aaronjeline (`@aaronjeline <https://github.com/aaronjeline>`_)
 - jerry2yu (`@jerry2yu <https://github.com/jerry2yu>`_)
 - Joshua Li <joshua.r.li.98@gmail.com> (`@JoshuaRLi <https://github.com/JoshuaRLi>`_)
+- Sébastien Eustace <sebastien@eustace.io> (`@sdispater <https://github.com/sdispater>`_)

--- a/Pipfile
+++ b/Pipfile
@@ -2,10 +2,9 @@
 humanize = "*"
 pytz = "*"
 dateparser = "*"
-iso8601 = "*"
-python-dateutil = "*"
 "ruamel.yaml" = "*"
 tzlocal = "*"
+pendulum = ">=1.0"
 
 [dev-packages]
 pytest = "*"

--- a/maya.py
+++ b/maya.py
@@ -16,8 +16,7 @@ from datetime import datetime as Datetime
 import pytz
 import humanize
 import dateparser
-import iso8601
-import dateutil.parser
+import pendulum
 from tzlocal import get_localzone
 
 _EPOCH_START = (1970, 1, 1)
@@ -131,8 +130,7 @@ class MayaDT(object):
     @classmethod
     def from_iso8601(klass, string):
         """Returns MayaDT instance from iso8601 string."""
-        dt = iso8601.parse_date(string)
-        return klass.from_datetime(dt)
+        return parse(string)
 
     @staticmethod
     def from_rfc2822(string):
@@ -272,11 +270,11 @@ def when(string, timezone='UTC'):
 def parse(string, day_first=False):
     """"Returns a MayaDT instance for the machine-produced moment specified.
 
-    Powered by dateutil. Accepts most known formats. Useful for working with data.
+    Powered by pendulum. Accepts most known formats. Useful for working with data.
 
     Keyword Arguments:
         string -- string to be parsed
         day_first -- if true, the first value (e.g. 01/05/2016) is parsed as day (default: False)
     """
-    dt = dateutil.parser.parse(string, dayfirst=day_first)
+    dt = pendulum.parse(string, day_first=day_first)
     return MayaDT.from_datetime(dt)

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,9 @@ required = [
     'humanize',
     'pytz',
     'dateparser',
-    'iso8601',
-    'python-dateutil',
     'ruamel.yaml',
-    'tzlocal'
+    'tzlocal',
+    'pendulum'
 ]
 
 setup(

--- a/test_maya.py
+++ b/test_maya.py
@@ -18,6 +18,50 @@ def test_iso8601():
     assert r == d.iso8601()
 
 
+def test_parse_iso8601():
+    string = '20161001T1430.4+05:30'
+    expected = '2016-10-01T09:00:00.400000Z'
+    d = maya.MayaDT.from_iso8601(string)
+
+    assert expected == d.iso8601()
+
+    string = '2016T14'
+    expected = '2016-01-01T14:00:00Z'
+    d = maya.MayaDT.from_iso8601(string)
+
+    assert expected == d.iso8601()
+
+    string = '2016-10T14'
+    expected = '2016-10-01T14:00:00Z'
+    d = maya.MayaDT.from_iso8601(string)
+
+    assert expected == d.iso8601()
+
+    string = '2012W05'
+    expected = '2012-01-30T00:00:00Z'
+    d = maya.MayaDT.from_iso8601(string)
+
+    assert expected == d.iso8601()
+
+    string = '2012W055'
+    expected = '2012-02-03T00:00:00Z'
+    d = maya.MayaDT.from_iso8601(string)
+
+    assert expected == d.iso8601()
+
+    string = '2012007'
+    expected = '2012-01-07T00:00:00Z'
+    d = maya.MayaDT.from_iso8601(string)
+
+    assert expected == d.iso8601()
+
+    string = '2016-W07T09'
+    expected = '2016-02-15T09:00:00Z'
+    d = maya.MayaDT.from_iso8601(string)
+
+    assert expected == d.iso8601()
+
+
 def test_human_when():
     r1 = maya.when('yesterday')
     r2 = maya.when('today')


### PR DESCRIPTION
This PR improves ISO8601 parsing by using `pendulum`.

Basically, `from_iso8601()` now calls `parse()` which uses the `pendulum` parser (which fallbacks on the `dateutil` parser when the string is not supported, so it should be backwards compatible).

I also removed `iso8601` and `python-dateutil` from the direct dependencies, the former is no longer necessary and the latter is a dependency of `pendulum`.

Fixes #49.