### PR TITLE
Regenerate lock file for 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ python:
   - "3.6"
 
 # command to install dependencies
-install: pip install pipenv; pipenv install --dev
+install: pip install pipenv; pipenv lock; pipenv install --dev
 # command to run tests
 script: pipenv run pytest


### PR DESCRIPTION
Maya uses `ruamel.yaml` which needs `ruamel.ordereddict` under 2.7 but does not under 3.x.  `ruamel.ordereddict` doesn't build under 3.x.  Maya's Pipfile.lock file was created under 2.7 so `ruamel.ordereddict` is listed as a dependency.

closes #55 