### PR TITLE
fix 'seconds_or_timedelta' to return ONLY 'datetime.timedelta' object

### DIFF
--- a/maya/core.py
+++ b/maya/core.py
@@ -302,7 +302,8 @@ class MayaInterval(object):
                 'Exactly 2 of start, end, and duration must be specified')
 
         # Convert duration to timedelta if seconds were provided.
-        duration = seconds_or_timedelta(duration)
+        if duration:
+            duration = seconds_or_timedelta(duration)
 
         if not start:
             start = end - duration
@@ -560,12 +561,20 @@ def parse(string, day_first=False):
     return MayaDT.from_datetime(dt)
 
 
-def seconds_or_timedelta(s):
-    # Convert seconds into timedelta.
-    if isinstance(s, int):
-        s = timedelta(seconds=s)
+def seconds_or_timedelta(duration):
+    """Returns `datetime.timedelta` object for the passed duration.
 
-    return s
+    Keyword Arguments:
+        duration -- `datetime.timedelta` object or seconds in `int` format.
+    """
+    if isinstance(duration, int):
+        dt_timedelta = timedelta(seconds=duration)
+    elif isinstance(duration, timedelta):
+        dt_timedelta = duration
+    else:
+        raise TypeError('Expects argument as `datetime.timedelta` object '
+                        'or seconds in `int` format')
+    return dt_timedelta
 
 
 def intervals(start, end, interval):

--- a/tests/test_maya.py
+++ b/tests/test_maya.py
@@ -204,6 +204,17 @@ def test_comparison_operations():
     with pytest.raises(TypeError):
         now >= 1
 
+
+def test_seconds_or_timedelta():
+    # test for value in seconds
+    assert maya.seconds_or_timedelta(1234) == timedelta(0, 1234)
+    # test for value as `datetime.timedelta`
+    assert maya.seconds_or_timedelta(timedelta(0, 1234)) == timedelta(0, 1234)
+    # test for invalid value
+    with pytest.raises(TypeError):
+        maya.seconds_or_timedelta('invalid interval')
+
+
 def test_intervals():
     now = maya.now()
     tomorrow = now.add(days=1)


### PR DESCRIPTION
`seconds_or_timedelta()` should always return an object of type `datetime.timedelta` in order to follow the principle of least surprise.

- `seconds_or_timedelta` with validation to follow this behavior. 

- Handled pass of `None` to "seconds_or_timedelta" in `MayaInterval` class

- added related test case