### PR TITLE
Raise ValueError instead of AssertionError

### DIFF
--- a/maya/core.py
+++ b/maya/core.py
@@ -415,7 +415,9 @@ class MayaInterval(object):
         # Convert seconds to timedelta, if appropriate.
         duration = seconds_or_timedelta(duration)
 
-        assert duration > timedelta(seconds=0), 'cannot call split with a non-positive timedelta'
+        if duration <= timedelta(seconds=0):
+            raise ValueError('cannot call split with a non-positive timedelta')
+
         start = self.start
         while start < self.end:
             if start + duration <= self.end:
@@ -431,7 +433,10 @@ class MayaInterval(object):
         duration = seconds_or_timedelta(duration)
         timezone = pytz.timezone(timezone)
 
-        assert duration > timedelta(seconds=0), 'cannot quantize by non-positive timedelta'
+
+        if duration <= timedelta(seconds=0):
+            raise ValueError('cannot quantize by non-positive timedelta')
+
         epoch = timezone.localize(Datetime(1970, 1, 1))
         seconds = int(duration.total_seconds())
 

--- a/tests/test_maya_interval.py
+++ b/tests/test_maya_interval.py
@@ -387,10 +387,10 @@ def test_interval_split_non_positive_delta():
     end = start.add(days=1)
     interval = maya.MayaInterval(start=start, end=end)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         list(interval.split(timedelta(seconds=0)))
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         list(interval.split(timedelta(seconds=-10)))
 
 
@@ -442,9 +442,10 @@ def test_quantize_invalid_delta():
     end = start.add(days=1)
     interval = maya.MayaInterval(start=start, end=end)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         interval.quantize(timedelta(minutes=0))
-    with pytest.raises(AssertionError):
+
+    with pytest.raises(ValueError):
         interval.quantize(timedelta(minutes=-1))
 
 


### PR DESCRIPTION
I think is more appropriate to raise a `ValueError` in those situations.

Depends on fix from #69 