### PR TITLE
Added duration length equality function

### DIFF
--- a/maya/core.py
+++ b/maya/core.py
@@ -526,6 +526,27 @@ class MayaInterval(object):
         return self.start <= dt < self.end
 
     @validate_arguments_type_of_function()
+    def same_duration_as(self, dt):
+        """
+        Compare to MayaIntervalObjects for equivalent duration length
+        :param dt: MayaInterval with duration property to compare against
+        :type dt: MayaInterval
+        :returns: Whether durations are equivalent in length
+        :rtype: bool
+
+        :Example:
+
+        >>>from maya import MayaInterval
+        >>>first = MayaInterval(start=maya.now(), duration=4)
+        >>>second = MayaInterval(start=maya.now(), duration=5)
+        >>>first.same_duration_as(first)
+        True
+        >>>first.same_duration_as(second)
+        False
+        """
+        return self.duration == dt.duration
+
+    @validate_arguments_type_of_function()
     def is_adjacent(self, maya_interval):
         return (
             self.start == maya_interval.end or

--- a/tests/test_maya_interval.py
+++ b/tests/test_maya_interval.py
@@ -260,6 +260,13 @@ def test_interval_iter():
     assert tuple(maya.MayaInterval(start=start, end=end)) == (start, end)
 
 
+def test_same_duration_as():
+    base = maya.now()
+    first = maya.MayaInterval(start=base, duration=4)
+    second = maya.MayaInterval(start=base, duration=5)
+    assert first.same_duration_as(first)
+    assert not first.same_duration_as(second)
+
 @pytest.mark.parametrize('start1,end1,start2,end2,expected', [
     (1, 2, 1, 2, 0),
     (1, 3, 2, 4, -1),


### PR DESCRIPTION
added a function for testing equality of duration length between
interval objects. Strict Equality still defined as equivalent start and
end for two MayaInterval objects

could use some of the TypeDecoration in the library by @moin18 which i don't know much about.

Addresses #73 

Signed-off-by: Evan.Mattiza <emattiza@gmail.com>
