### PR TITLE
Fixed setup.py bug by turning encoding into a keyword argument. Encod…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ packages = [
 
 # About dict to store version and package info
 about = dict()
-with open(os.path.join(here, 'maya', '__version__.py'), 'r', 'utf-8') as f:
+with open(os.path.join(here, 'maya', '__version__.py'), 'r', encoding='utf-8') as f:
     exec(f.read(), about)
 
 setup(


### PR DESCRIPTION
…ing parameter was being passed in the position belonging to the buffering parameter