### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ Behold, datetimes for humans!
     UTC
 
     # Range of hours in a day:
-    >>> maya.interval(start=maya.now(), end=maya.now().add(days=1), interval=60*60)
+    >>> maya.intervals(start=maya.now(), end=maya.now().add(days=1), interval=60*60)
     <generator object intervals at 0x105ba5820>
 
 ☤ Advanced Usage of Maya


### PR DESCRIPTION
The example for intervals is missing an "s"

>>> import maya
>>> maya.interval(start=maya.now(), end=maya.now().add(days=1), interval=60*60)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'maya' has no attribute 'interval'
>>> maya.intervals(start=maya.now(), end=maya.now().add(days=1), interval=60*60)
<generator object intervals at 0x106acc0a0>