### PR TITLE
Fixes #98 - add support for time struct with test and docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,15 @@ Behold, datetimes for humans!
     >>> rand_day = maya.when('2011-02-07', timezone='US/Eastern')
     <MayaDT epoch=1297036800.0>
 
+    # Maya speaks Python
+    >>> m = maya.MayaDT.from_datetime(datetime.utcnow())
+    >>> print(m)
+    Wed, 20 Sep 2017 17:24:32 GMT
+    
+    >>> m = maya.MayaDT.from_struct(time.gmtime())
+    >>> print(m)
+    Wed, 20 Sep 2017 17:24:32 GMT 
+
     >>> rand_day.day
     7
 

--- a/maya/core.py
+++ b/maya/core.py
@@ -176,6 +176,14 @@ class MayaDT(object):
     def from_datetime(klass, dt):
         """Returns MayaDT instance from datetime."""
         return klass(klass.__dt_to_epoch(dt))
+    
+    @classmethod
+    @validate_arguments_type_of_function(time.struct_time)
+    def from_struct(klass, struct, timezone=pytz.UTC):
+        """Returns MayaDT instance from a 9-tuple struct""" 
+        struct_time = time.mktime(struct)
+        dt = Datetime.fromtimestamp(struct_time, timezone)
+        return klass(klass.__dt_to_epoch(dt))
 
     @classmethod
     def from_iso8601(klass, iso8601_string):

--- a/tests/test_maya.py
+++ b/tests/test_maya.py
@@ -1,6 +1,8 @@
 import pytest
+import pytz
 import copy
-from datetime import timedelta
+import time
+from datetime import date, timedelta, datetime as Datetime
 
 import maya
 from maya.core import _seconds_or_timedelta  # import private function
@@ -63,6 +65,18 @@ def test_parse_iso8601():
 
     assert expected == d.iso8601()
 
+def test_struct():
+    ts = time.gmtime()
+    m = maya.MayaDT.from_struct(ts)
+    dt = Datetime.fromtimestamp(time.mktime(ts), pytz.UTC)
+    assert m._epoch != None
+    assert m.datetime() == dt
+
+    ts = time.localtime()
+    m = maya.MayaDT.from_struct(ts)
+    dt = Datetime.fromtimestamp(time.mktime(ts), pytz.UTC)
+    assert m._epoch != None
+    assert m.datetime() == dt 
 
 def test_human_when():
     r1 = maya.when('yesterday')


### PR DESCRIPTION
Adds `from_struct`. Please sanity check my approach to timezones, making sure that they fit the `maya` approach.