### PR TITLE
Added an alias for parse as parce - a common misspelling

### DIFF
--- a/maya/core.py
+++ b/maya/core.py
@@ -612,6 +612,7 @@ def parse(string, day_first=False):
     dt = pendulum.parse(string, day_first=day_first)
     return MayaDT.from_datetime(dt)
 
+parce = parse
 
 def _seconds_or_timedelta(duration):
     """Returns `datetime.timedelta` object for the passed duration.


### PR DESCRIPTION
I, and I am sure several others, have this horrible habit of not being able to spell parse correctly. 