### PR TITLE
Support year_first in maya.parse. Closes #102

### DIFF
--- a/maya/core.py
+++ b/maya/core.py
@@ -605,16 +605,18 @@ def when(string, timezone='UTC', prefer_past=False):
     return MayaDT.from_datetime(dt)
 
 
-def parse(string, day_first=False):
+def parse(string, day_first=False, year_first=True):
     """"Returns a MayaDT instance for the machine-produced moment specified.
 
     Powered by pendulum. Accepts most known formats. Useful for working with data.
 
     Keyword Arguments:
         string -- string to be parsed
-        day_first -- if true, the first value (e.g. 01/05/2016) is parsed as day (default: False)
+        day_first -- if true, the first value (e.g. 01/05/2016) is parsed as day.
+                     if year_first is set to True, this distinguishes between YDM and YMD. (default: False)
+        year_first -- if true, the first value (e.g. 2016/05/01) is parsed as year (default: True)
     """
-    dt = pendulum.parse(string, day_first=day_first)
+    dt = pendulum.parse(string, day_first=day_first, year_first=year_first)
     return MayaDT.from_datetime(dt)
 
 

--- a/tests/test_maya.py
+++ b/tests/test_maya.py
@@ -65,6 +65,7 @@ def test_parse_iso8601():
 
     assert expected == d.iso8601()
 
+
 def test_struct():
     ts = time.gmtime()
     m = maya.MayaDT.from_struct(ts)
@@ -76,7 +77,8 @@ def test_struct():
     m = maya.MayaDT.from_struct(ts)
     dt = Datetime.fromtimestamp(time.mktime(ts), pytz.UTC)
     assert m._epoch != None
-    assert m.datetime() == dt 
+    assert m.datetime() == dt
+
 
 def test_human_when():
     r1 = maya.when('yesterday')
@@ -170,6 +172,13 @@ def test_parse():
     d = maya.parse('01/05/2016', day_first=True)
     assert format(d) == '2016-05-01 00:00:00+00:00'
 
+    d = maya.parse('2016/05/01', year_first=True, day_first=False)
+    assert format(d) == '2016-05-01 00:00:00+00:00'
+
+    d = maya.parse('2016/01/05', year_first=True, day_first=True)
+    assert format(d) == '2016-05-01 00:00:00+00:00'
+
+
 def test_when_past():
     next_month = str(maya.now().add(months=1).month)
     this_year = maya.now().year
@@ -185,6 +194,7 @@ def test_when_past():
 def test_datetime_to_timezone():
     dt = maya.when('2016-01-01').datetime(to_timezone='US/Eastern')
     assert dt.tzinfo.zone == 'US/Eastern'
+
 
 def test_rfc3339():
     mdt =  maya.when('2016-01-01')
@@ -265,7 +275,7 @@ def test_dunder_sub():
     assert now - 1 == now.subtract(seconds=1)
     assert now - timedelta(seconds=1) == now.subtract(seconds=1)
 
-    
+
 def test_core_local_timezone(monkeypatch):
     @property
     def mock_local_tz(self):


### PR DESCRIPTION
This change adds support for a `year_first` keyword argument to the
`maya.parse` function. `maya` will forward this argument to pendulum
which then lets `dateutil.parse` do the work.

See https://dateutil.readthedocs.io/en/stable/parser.html#dateutil.parser.parse for the `dateutil.parse` documentation. 

I think if maya supports `day_first` it has to support `year_first` as well. With that dates like YDM are supported.
