### PR TITLE
Fix prefer_past test in December

### DIFF
--- a/tests/test_maya.py
+++ b/tests/test_maya.py
@@ -188,7 +188,10 @@ def test_when_past():
     past_date = maya.when(next_month, prefer_past=True)
 
     assert future_date.year == this_year
-    assert past_date.year == last_year
+    if next_month == '1':
+        assert past_date.year == this_year
+    else:
+        assert past_date.year == last_year
 
 
 def test_datetime_to_timezone():


### PR DESCRIPTION
In December  `dateparser` no longer assumes a yearless month is in the future so it will output the same result for `prefer_past=False` and `prefer_past=True`.

This fixes a currently causing a failing test in master.