### PR TITLE
Issue 104

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,3 +23,4 @@ In chronological order:
 - Sébastien Eustace <sebastien@eustace.io> (`@sdispater <https://github.com/sdispater>`_)
 - Evan Mattiza <emattiza@gmail.com> (`@emattiza <https://github.com/emattiza>`_)
 - Dima Spivak <dima@spivak.ch> (`@dimaspivak <https://github.com/dimaspivak>`_)
+- Tom Barron <tusculum@gmail.com> (`@dtbarron <https://github.com/tbarron>`_)

--- a/maya/core.py
+++ b/maya/core.py
@@ -176,12 +176,12 @@ class MayaDT(object):
     def from_datetime(klass, dt):
         """Returns MayaDT instance from datetime."""
         return klass(klass.__dt_to_epoch(dt))
-    
+
     @classmethod
     @validate_arguments_type_of_function(time.struct_time)
     def from_struct(klass, struct, timezone=pytz.UTC):
-        """Returns MayaDT instance from a 9-tuple struct""" 
-        struct_time = time.mktime(struct)
+        """Returns MayaDT instance from a 9-tuple struct (assumed to be from gmtime())"""
+        struct_time = time.mktime(struct) - utc_offset()
         dt = Datetime.fromtimestamp(struct_time, timezone)
         return klass(klass.__dt_to_epoch(dt))
 
@@ -296,6 +296,16 @@ class MayaDT(object):
         """"Returns human slang representation of time."""
         dt = self.datetime(naive=True, to_timezone=self.local_timezone)
         return humanize.naturaltime(dt)
+
+
+def utc_offset():
+    """Returns the current local time offset from UTC accounting for DST """
+    ts = time.localtime()
+    if ts[-1]:
+        offset = time.altzone
+    else:
+        offset = time.timezone
+    return offset
 
 
 def to_utc_offset_naive(dt):

--- a/tests/test_maya.py
+++ b/tests/test_maya.py
@@ -67,17 +67,28 @@ def test_parse_iso8601():
 
 
 def test_struct():
-    ts = time.gmtime()
+    now = round(time.time())
+    ts = time.gmtime(now)
     m = maya.MayaDT.from_struct(ts)
-    dt = Datetime.fromtimestamp(time.mktime(ts), pytz.UTC)
+    dt = Datetime.fromtimestamp(now, pytz.UTC)
     assert m._epoch != None
     assert m.datetime() == dt
 
-    ts = time.localtime()
+    ts = time.localtime(now)
     m = maya.MayaDT.from_struct(ts)
-    dt = Datetime.fromtimestamp(time.mktime(ts), pytz.UTC)
+    dt = Datetime.fromtimestamp(time.mktime(ts) - maya.core.utc_offset(), pytz.UTC)
     assert m._epoch != None
     assert m.datetime() == dt
+
+
+def test_issue_104():
+    e = 1507756331
+    t = Datetime.utcfromtimestamp(e)
+    t = maya.MayaDT.from_datetime(t)
+    assert str(t) == 'Wed, 11 Oct 2017 21:12:11 GMT'
+    t = time.gmtime(e)
+    t = maya.MayaDT.from_struct(t)
+    assert str(t) == 'Wed, 11 Oct 2017 21:12:11 GMT'
 
 
 def test_human_when():


### PR DESCRIPTION
This update addresses issue #104, where the .from_struct() was not behaving quite as described in the README. 

Specifically, (as I understand it) from_struct() depends on time.mktime(), which assumes its input was generated by time.localtime() rather than time.gmtime(). The upshot is that the result returned from time.mktime() has to be adjusted back to UTC. To do this, I added function utc_offset(), which returns the number of seconds to add or subtract to go back and forth between local time and UTC. It takes DST into account by looking at the last value in the tuple returned by localtime().