### PR TITLE
Add date property to MayaDT

### DIFF
--- a/maya/core.py
+++ b/maya/core.py
@@ -254,6 +254,10 @@ class MayaDT(object):
     @property
     def day(self):
         return self.datetime().day
+    
+    @property
+    def date(self):
+        return self.datetime().date()
 
     @property
     def week(self):


### PR DESCRIPTION
As title says. Sometimes you just need to work with dates and `date.datetime().date()` is a bit convoluted.