### PR TITLE
fix `pendulum>=1.0` in setup.py (was missing version)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ required = [
     'pytz',
     'dateparser>=0.7.0',
     'tzlocal',
-    'pendulum',
+    'pendulum>=1.0',
     'snaptime'
 ]
 


### PR DESCRIPTION
Assuming, that when Pipfile declares such rule, it shall be also in
setup.py.