### PR TITLE
.when with weekdays and prefer_past

### DIFF
--- a/maya/core.py
+++ b/maya/core.py
@@ -675,7 +675,7 @@ def now():
     return MayaDT(epoch=epoch)
 
 
-def when(string, timezone='UTC', prefer_past=False):
+def when(string, timezone='UTC', prefer_past=None):
     """"Returns a MayaDT instance for the human moment specified.
 
     Powered by dateparser. Useful for scraping websites.
@@ -694,8 +694,12 @@ def when(string, timezone='UTC', prefer_past=False):
         'RETURN_AS_TIMEZONE_AWARE': True,
         'TO_TIMEZONE': 'UTC',
     }
-    if prefer_past:
+
+    if prefer_past is False:
+        settings['PREFER_DATES_FROM'] = 'future'
+    if prefer_past is True:
         settings['PREFER_DATES_FROM'] = 'past'
+
     dt = dateparser.parse(string, settings=settings)
     if dt is None:
         raise ValueError('invalid datetime input specified.')

--- a/maya/core.py
+++ b/maya/core.py
@@ -675,7 +675,7 @@ def now():
     return MayaDT(epoch=epoch)
 
 
-def when(string, timezone='UTC', prefer_past=None):
+def when(string, timezone='UTC', prefer_dates_from='current_period'):
     """"Returns a MayaDT instance for the human moment specified.
 
     Powered by dateparser. Useful for scraping websites.
@@ -693,12 +693,8 @@ def when(string, timezone='UTC', prefer_past=None):
         'TIMEZONE': timezone,
         'RETURN_AS_TIMEZONE_AWARE': True,
         'TO_TIMEZONE': 'UTC',
+        'PREFER_DATES_FROM': prefer_dates_from,
     }
-
-    if prefer_past is False:
-        settings['PREFER_DATES_FROM'] = 'future'
-    if prefer_past is True:
-        settings['PREFER_DATES_FROM'] = 'past'
 
     dt = dateparser.parse(string, settings=settings)
     if dt is None:

--- a/maya/core.py
+++ b/maya/core.py
@@ -686,8 +686,12 @@ def when(string, timezone='UTC', prefer_dates_from='current_period'):
     Keyword Arguments:
         string -- string to be parsed
         timezone -- timezone referenced from (default: 'UTC')
-        prefer_past -- prefer parsing ambiguous date as in the past
+        prefer_dates_from -- what dates are prefered when `string` is ambigous.
+                             options are 'past', 'future', and 'current_period'
+                             (default: 'current_period'). see: [1]
 
+    Reference:
+        [1] dateparser.readthedocs.io/en/latest/usage.html#handling-incomplete-dates
     """
     settings = {
         'TIMEZONE': timezone,

--- a/tests/test_maya.py
+++ b/tests/test_maya.py
@@ -194,7 +194,9 @@ def test_parse(string, kwds, expected):
 def test_when_past():
     two_days_away = maya.now().add(days=2)
 
-    past_date = maya.when(two_days_away.slang_date(), prefer_past=True)
+    past_date = maya.when(
+            two_days_away.slang_date(),
+            prefer_dates_from='past')
 
     assert past_date < maya.now()
 
@@ -203,7 +205,9 @@ def test_when_past():
 def test_when_future():
     two_days_away = maya.now().add(days=2)
 
-    future_date = maya.when(two_days_away.slang_date(), prefer_past=False)
+    future_date = maya.when(
+            two_days_away.slang_date(),
+            prefer_dates_from='future')
 
     assert future_date > maya.now()
 
@@ -213,7 +217,8 @@ def test_when_past_day_name():
     two_days_away = maya.now().add(days=2)
 
     past_date = maya.when(
-            calendar.day_name[two_days_away.weekday], prefer_past=True)
+            calendar.day_name[two_days_away.weekday],
+            prefer_dates_from='past')
 
     assert past_date < maya.now()
 
@@ -223,7 +228,8 @@ def test_when_future_day_name():
     two_days_away = maya.now().add(days=2)
 
     future_date = maya.when(
-            calendar.day_name[two_days_away.weekday], prefer_past=False)
+            calendar.day_name[two_days_away.weekday],
+            prefer_dates_from='future')
 
     assert future_date > maya.now()
 

--- a/tests/test_maya.py
+++ b/tests/test_maya.py
@@ -1,5 +1,6 @@
 import copy
 import time
+import calendar
 from datetime import timedelta, datetime as Datetime
 
 import pytz
@@ -191,16 +192,40 @@ def test_parse(string, kwds, expected):
 
 @pytest.mark.usefixtures("frozen_now")
 def test_when_past():
-    next_month = str(maya.now().add(months=1).month)
-    this_year = maya.now().year
-    last_year = this_year - 1
-    future_date = maya.when(next_month)
-    past_date = maya.when(next_month, prefer_past=True)
-    assert future_date.year == this_year
-    if next_month == '1':
-        assert past_date.year == this_year
-    else:
-        assert past_date.year == last_year
+    two_days_away = maya.now().add(days=2)
+
+    past_date = maya.when(two_days_away.slang_date(), prefer_past=True)
+
+    assert past_date < maya.now()
+
+
+@pytest.mark.usefixtures("frozen_now")
+def test_when_future():
+    two_days_away = maya.now().add(days=2)
+
+    future_date = maya.when(two_days_away.slang_date(), prefer_past=False)
+
+    assert future_date > maya.now()
+
+
+@pytest.mark.usefixtures("frozen_now")
+def test_when_past_day_name():
+    two_days_away = maya.now().add(days=2)
+
+    past_date = maya.when(
+            calendar.day_name[two_days_away.weekday], prefer_past=True)
+
+    assert past_date < maya.now()
+
+
+@pytest.mark.usefixtures("frozen_now")
+def test_when_future_day_name():
+    two_days_away = maya.now().add(days=2)
+
+    future_date = maya.when(
+            calendar.day_name[two_days_away.weekday], prefer_past=False)
+
+    assert future_date > maya.now()
 
 
 def test_datetime_to_timezone():


### PR DESCRIPTION
This PR adds some more tests around `.when()` and the `prefer_past` paramenter.

I did change the test `test_when_past`. If you prefer the old test, I can change it back. Also, I added `test_when_future`, which is the opposite of `test_when_past`.

The other 2 tests: `test_when_past_day_name` and `test_when_future_day_name` (failing) to  demonstrate #146.