### PR TITLE
Fix RFC3339 representation

### DIFF
--- a/maya/core.py
+++ b/maya/core.py
@@ -277,7 +277,7 @@ class MayaDT(object):
 
     def rfc3339(self):
         """Returns an RFC 3339 representation of the MayaDT."""
-        return self.datetime().strftime("%Y-%m-%dT%H:%M:%S.%f")[:-4] + "Z"
+        return self.datetime().strftime("%Y-%m-%dT%H:%M:%S.%f")[:-5] + "Z"
 
     # Properties
     # ----------

--- a/tests/test_maya.py
+++ b/tests/test_maya.py
@@ -245,6 +245,11 @@ def test_rfc3339():
     mdt2 = maya.MayaDT.from_rfc3339(out)
     assert mdt.epoch == mdt2.epoch
 
+    rfc3339 = maya.MayaDT.rfc3339(maya.when('2016-01-01T12:03:03Z'))
+    # it's important that the string has got a "max 1-digit millis" fragment
+    # as per https://tools.ietf.org/html/rfc3339#section-5.6
+    assert rfc3339 == '2016-01-01T12:03:03.0Z'
+
 
 @pytest.mark.usefixtures("frozen_now")
 def test_comparison_operations():


### PR DESCRIPTION
https://now.httpbin.org/ returns an invalid RFC3339 representation. It currently shows 2-digit milliseconds. I hope I tracked it correctly back to Maya `core.py`.

RFC3339 5.6 allows at most 1 digit for milliseconds: https://tools.ietf.org/html/rfc3339#section-5.6.

```
time-secfrac    = "." 1*DIGIT
partial-time    = time-hour ":" time-minute ":" time-second [time-secfrac]
```

I'm not 100% happy with the fix as `.%f` apparently isn't guaranteed to always return 6 digits (platform dependent). https://stackoverflow.com/a/35643540/131929 shows a more stable version based on splitting and reformatting the original string.