### PR TITLE
Allow slang methods to change locale

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,3 +24,4 @@ In chronological order:
 - Evan Mattiza <emattiza@gmail.com> (`@emattiza <https://github.com/emattiza>`_)
 - Dima Spivak <dima@spivak.ch> (`@dimaspivak <https://github.com/dimaspivak>`_)
 - Tom Barron <tusculum@gmail.com> (`@dtbarron <https://github.com/tbarron>`_)
+- Alex Ward <alxwrd@gmail.com> (`@alxwrd <https://github.com/alxwrd>`_)

--- a/maya/core.py
+++ b/maya/core.py
@@ -336,10 +336,15 @@ class MayaDT(object):
         dt = self.datetime(naive=True, to_timezone=self.local_timezone)
         return humanize.naturaldate(dt)
 
-    def slang_time(self):
-        """"Returns human slang representation of time."""
-        dt = self.datetime(naive=True, to_timezone=self.local_timezone)
-        return humanize.naturaltime(dt)
+    def slang_time(self, locale="en"):
+        """"Returns human slang representation of time.
+
+        Keyword Arguments:
+            locale -- locale to translate too, e.g. 'fr' for french.
+                       (default: 'en' - English)
+        """
+        dt = self.datetime(to_timezone=self.local_timezone)
+        return pendulum.instance(dt).diff_for_humans(locale=locale)
 
 
 def utc_offset(time_struct=None):

--- a/maya/core.py
+++ b/maya/core.py
@@ -340,7 +340,7 @@ class MayaDT(object):
         """"Returns human slang representation of time.
 
         Keyword Arguments:
-            locale -- locale to translate too, e.g. 'fr' for french.
+            locale -- locale to translate to, e.g. 'fr' for french.
                        (default: 'en' - English)
         """
         dt = self.datetime(to_timezone=self.local_timezone)

--- a/maya/core.py
+++ b/maya/core.py
@@ -3,7 +3,6 @@
 # ||    | || ||  //  || ||
 import email.utils
 import time
-import calendar
 import functools
 from datetime import timedelta, datetime as Datetime
 

--- a/tests/test_maya.py
+++ b/tests/test_maya.py
@@ -158,9 +158,19 @@ def test_slang_date():
     assert d.slang_date() == 'tomorrow'
 
 
+def test_slang_date_locale():
+    d = maya.when('tomorrow')
+    assert d.slang_date(locale='fr') == 'demain'
+
+
 def test_slang_time():
     d = maya.when('1 hour ago')
     assert d.slang_time() == '1 hour ago'
+
+
+def test_slang_time_locale():
+    d = maya.when('1 hour ago')
+    assert d.slang_time(locale='de') == 'vor 1 Stunde'
 
 
 @pytest.mark.parametrize("string,kwds,expected", [

--- a/tests/test_maya.py
+++ b/tests/test_maya.py
@@ -160,7 +160,7 @@ def test_slang_date():
 
 def test_slang_time():
     d = maya.when('1 hour ago')
-    assert d.slang_time() == 'an hour ago'
+    assert d.slang_time() == '1 hour ago'
 
 
 @pytest.mark.parametrize("string,kwds,expected", [


### PR DESCRIPTION
This attempts to add internationalisation/localisation to the `slang_` methods to address #84.

I originally attempted to use the localisation built into humanize. However, I had the issue that the last [release](https://github.com/jmoiron/humanize/releases) for humanize was in 2014, and at the time it only supported [3 locales](https://github.com/jmoiron/humanize/tree/0.5.1/humanize/locale).

Because of this, I switched to using pendulum which has a [much bigger](https://github.com/sdispater/pendulum/tree/9c588843e8f0747ba30e06e34b394a6dd2284335/pendulum/locales) locale selection.

However, pendulum only has `diff_for_humans()` which is for time. This leaves `slang_date` without localisation.

I think the questions that are left are:
- Does `slang_date` just get left for now?
- Do we just use the limited locales provided by `humanize`?
