### PR TITLE
Add Example of Creating a MayaDT Using a Unix Time

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,10 @@ Behold, datetimes for humans!
     >>> m = maya.MayaDT.from_struct(time.gmtime())
     >>> print(m)
     Wed, 20 Sep 2017 17:24:32 GMT
+    
+    >>> m = maya.MayaDT(time.time())
+    >>> print(m)
+    Wed, 20 Sep 2017 17:24:32 GMT
 
     >>> rand_day.day
     7


### PR DESCRIPTION
- This PR adds a new example to the README: creating a `MayaDT` with a unix time
    - (Currently there is no direct README documentation for `MayaDT.__init__` / converting from unix times to `MayaDT` -- only indirect hints from the `MayaDT` `__repr__`)