### PR TITLE
Fallback on error in datetime() before year 1970

### DIFF
--- a/src/maya/core.py
+++ b/src/maya/core.py
@@ -257,7 +257,10 @@ class MayaDT(object):
         if to_timezone:
             dt = self.datetime().astimezone(pytz.timezone(to_timezone))
         else:
-            dt = Datetime.utcfromtimestamp(self._epoch)
+            try:
+                dt = Datetime.utcfromtimestamp(self._epoch)
+            except: # Fallback for before year 1970 issue
+                dt = Datetime.utcfromtimestamp(0) + timedelta(microseconds=self._epoch*1000000)
             dt.replace(tzinfo=self._tz)
         # Strip the timezone info if requested to do so.
         if naive:

--- a/tests/test_maya.py
+++ b/tests/test_maya.py
@@ -86,6 +86,28 @@ def test_issue_104():
     t = maya.MayaDT.from_struct(t)
     assert str(t) == "Wed, 11 Oct 2017 21:12:11 GMT"
 
+def test_before_1970():
+    d1 = maya.when("1899-17-11 08:09:10")
+    assert d1.year == 1899
+    assert d1.month == 11
+    assert d1.day == 17
+    assert d1.week == 46
+    assert d1.weekday == 5
+    assert d1.hour == 8
+    assert d1.minute == 9
+    assert d1.second == 10
+    assert d1.microsecond == 0
+    # Test properties for maya.parse()
+    d2 = maya.parse("February 29, 1904 13:12:34")
+    assert d2.year == 1904
+    assert d2.month == 2
+    assert d2.day == 29
+    assert d2.week == 9
+    assert d2.weekday == 1
+    assert d2.hour == 13
+    assert d2.minute == 12
+    assert d2.second == 34
+    assert d2.microsecond == 0
 
 def test_human_when():
     r1 = maya.when("yesterday")


### PR DESCRIPTION
**Describe the bug**
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Anaconda\python3\envs\***\lib\site-packages\maya\core.py", line 250, in datetime
    dt = Datetime.utcfromtimestamp(self._epoch)
OSError: [Errno 22] Invalid argument
```
when MayaDT.datatime() (calls utcfromtimestamp) with negative epoch MayaDT object.

**Environment and Version**
* OS (incl. terminal and shell used): Powershell with Microsoft Windows 10 Home 10.0.19042
* Python Version: 3.7.9
* maya Version: 0.6.1
* Your timezone: Japan Time (+09:00)

**To Reproduce**
( note that occured on Windows environment , but maybe not on Linux environment )

```python
import maya
maya.when("1949-01-01").datetime()
```

**Expected behavior**

```python
>>> import maya
>>> maya.when("1949-01-01").datetime()
datetime.datetime(1949, 1, 1, 0, 0, tzinfo=<UTC>)
```

